### PR TITLE
add podlabels option to the helm value

### DIFF
--- a/stable/spark-history-server/templates/deployment.yaml
+++ b/stable/spark-history-server/templates/deployment.yaml
@@ -22,6 +22,9 @@ spec:
     {{- end }}
       labels:
         {{- include "spark-history-server.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/spark-history-server/values.yaml
+++ b/stable/spark-history-server/values.yaml
@@ -35,6 +35,9 @@ sparkConf: |-
 
 podAnnotations: {}
 
+# Extra custom labels for pods
+podLabels: {}
+
 podSecurityContext:
   runAsUser: 1000
   fsGroup: 1000


### PR DESCRIPTION
Making change to value.yaml to add podlabels for custom label and deployment.yaml template to use it 

```
metadata:
    labels:
      app.kubernetes.io/name: spark-history-server
      app.kubernetes.io/instance: spark-history-server
      logging.custom.io/stream: custom-value
 ```