### PR TITLE
Update values.yaml

### DIFF
--- a/stable/spark-history-server/values.yaml
+++ b/stable/spark-history-server/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: varabonthu/spark-web-ui
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 1.0.6
+  tag: 1.3.1
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Updated Docker image tag:
The tag for the Docker image used by the Spark History Server Helm chart was updated from 1.0.6 to 1.3.1.

Reason for the update:
This change ensures that deployments use the latest stable version of the image, which likely includes bug fixes, security updates, and new features introduced since 1.0.6.

Potential Impact:
Deployments of this chart will now pull and run the 1.3.1 version of the image. Please verify that your workloads are compatible with this new version and review the release notes for any breaking changes.
