### PR TITLE
fix logging configurations

### DIFF
--- a/stable/spark-history-server/templates/configmap.yaml
+++ b/stable/spark-history-server/templates/configmap.yaml
@@ -39,5 +39,5 @@ data:
     {{- toYaml .Values.sparkConf | nindent 4 }}
     {{- end }}
 
-  log4j.properties:
+  log4j2.properties:
 {{- toYaml .Values.log4jConfig | nindent 4 }}

--- a/stable/spark-history-server/templates/deployment.yaml
+++ b/stable/spark-history-server/templates/deployment.yaml
@@ -65,8 +65,8 @@ spec:
               mountPath: /opt/spark/conf/spark-defaults.conf
               subPath: spark-defaults.conf
             - name: config-volume
-              mountPath: /opt/spark/conf/log4j.properties
-              subPath: log4j.properties
+              mountPath: /opt/spark/conf/log4j2.properties
+              subPath: log4j2.properties
             - name: spark-logs
               mountPath: /opt/spark/logs
           ports:

--- a/stable/spark-history-server/tests/spark_config_test.yaml
+++ b/stable/spark-history-server/tests/spark_config_test.yaml
@@ -15,16 +15,23 @@ tests:
       - equal:
           path: data
           value:
-            log4j.properties: |-
-              log4j.rootCategory=INFO, console
-              log4j.appender.console=org.apache.log4j.ConsoleAppender
-              log4j.appender.console.target=System.out
-              log4j.appender.console.layout=org.apache.log4j.PatternLayout
-              log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
-              log4j.logger.org.apache.spark=INFO
-              log4j.logger.org.apache.hadoop=INFO
-              log4j.logger.org.apache.hadoop.fs.s3a=DEBUG
-              log4j.logger.org.apache.spark.deploy.history.FsHistoryProvider=DEBUG
+            log4j2.properties: |-
+              rootLogger.level = info
+              rootLogger.appenderRef.stdout.ref = console
+              appender.console.type = Console
+              appender.console.name = console
+              appender.console.target = SYSTEM_ERR
+              appender.console.layout.type = PatternLayout
+              appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n%ex
+
+              logger.spark.name = org.apache.spark
+              logger.spark.level = INFO
+              logger.hadoop.name = org.apache.hadoop
+              logger.hadoop.level = INFO
+              logger.s3a.name = org.apache.hadoop.fs.s3a
+              logger.s3a.level = DEBUG
+              logger.history.name = org.apache.spark.deploy.history.FsHistoryProvider
+              logger.history.level = DEBUG
             spark-defaults.conf: |-
               spark.history.fs.logDirectory=s3a://my-spark-logs/spark-events/
               spark.hadoop.fs.s3a.aws.credentials.provider=com.amazonaws.auth.WebIdentityTokenCredentialsProvider
@@ -59,16 +66,23 @@ tests:
       - equal:
           path: data
           value:
-            log4j.properties: |-
-              log4j.rootCategory=INFO, console
-              log4j.appender.console=org.apache.log4j.ConsoleAppender
-              log4j.appender.console.target=System.out
-              log4j.appender.console.layout=org.apache.log4j.PatternLayout
-              log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
-              log4j.logger.org.apache.spark=INFO
-              log4j.logger.org.apache.hadoop=INFO
-              log4j.logger.org.apache.hadoop.fs.s3a=DEBUG
-              log4j.logger.org.apache.spark.deploy.history.FsHistoryProvider=DEBUG
+            log4j2.properties: |-
+              rootLogger.level = info
+              rootLogger.appenderRef.stdout.ref = console
+              appender.console.type = Console
+              appender.console.name = console
+              appender.console.target = SYSTEM_ERR
+              appender.console.layout.type = PatternLayout
+              appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n%ex
+
+              logger.spark.name = org.apache.spark
+              logger.spark.level = INFO
+              logger.hadoop.name = org.apache.hadoop
+              logger.hadoop.level = INFO
+              logger.s3a.name = org.apache.hadoop.fs.s3a
+              logger.s3a.level = DEBUG
+              logger.history.name = org.apache.spark.deploy.history.FsHistoryProvider
+              logger.history.level = DEBUG
             spark-defaults.conf: |-
               spark.history.fs.logDirectory=abfss://my-container@mystorageaccount.dfs.core.windows.net/spark-events
               spark.hadoop.fs.azure.account.auth.type.mystorageaccount.dfs.core.windows.net=OAuth

--- a/stable/spark-history-server/values.yaml
+++ b/stable/spark-history-server/values.yaml
@@ -60,15 +60,22 @@ logStore:
 #  spark.ui.proxyBase=/history
 
 log4jConfig: |-
-  log4j.rootCategory=INFO, console
-  log4j.appender.console=org.apache.log4j.ConsoleAppender
-  log4j.appender.console.target=System.out
-  log4j.appender.console.layout=org.apache.log4j.PatternLayout
-  log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
-  log4j.logger.org.apache.spark=INFO
-  log4j.logger.org.apache.hadoop=INFO
-  log4j.logger.org.apache.hadoop.fs.s3a=DEBUG
-  log4j.logger.org.apache.spark.deploy.history.FsHistoryProvider=DEBUG
+  rootLogger.level = info
+  rootLogger.appenderRef.stdout.ref = console
+  appender.console.type = Console
+  appender.console.name = console
+  appender.console.target = SYSTEM_ERR
+  appender.console.layout.type = PatternLayout
+  appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n%ex
+
+  logger.spark.name = org.apache.spark
+  logger.spark.level = INFO
+  logger.hadoop.name = org.apache.hadoop
+  logger.hadoop.level = INFO
+  logger.s3a.name = org.apache.hadoop.fs.s3a
+  logger.s3a.level = DEBUG
+  logger.history.name = org.apache.spark.deploy.history.FsHistoryProvider
+  logger.history.level = DEBUG
 
 historyServer:
   fs:


### PR DESCRIPTION
Currently there are no log messages printed to stdout because the configuration file for loggers is using log4j format. 

With this change, we now get logs properly.

```
starting org.apache.spark.deploy.history.HistoryServer, logging to /opt/spark/logs/spark--org.apache.spark.deploy.history.HistoryServer-1-003658ffe276.out
Spark Command: /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/java -cp /opt/spark/conf/:/opt/spark/jars/* -Dlog4j2.configurationFile=file:/tmp/log4j2.properties -Xmx1g org.apache.spark.deploy.history.HistoryServer
========================================
25/07/02 22:49:42 INFO HistoryServer: Started daemon with process name: 311@003658ffe276
25/07/02 22:49:42 INFO SignalUtils: Registering signal handler for TERM
25/07/02 22:49:42 INFO SignalUtils: Registering signal handler for HUP
25/07/02 22:49:42 INFO SignalUtils: Registering signal handler for INT
25/07/02 22:49:42 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
25/07/02 22:49:42 INFO SecurityManager: Changing view acls to: 1000
25/07/02 22:49:42 INFO SecurityManager: Changing modify acls to: 1000
25/07/02 22:49:42 INFO SecurityManager: Changing view acls groups to:
25/07/02 22:49:42 INFO SecurityManager: Changing modify acls groups to:
25/07/02 22:49:42 INFO SecurityManager: SecurityManager: authentication disabled; ui acls disabled; users with view permissions: 1000; groups with view permissions: EMPTY; users with modify permissions: 1000; groups with modify permissions: EMPTY
25/07/02 22:49:43 INFO FsHistoryProvider: History server ui acls disabled; users with admin permissions: ; groups with admin permissions:
25/07/02 22:49:43 INFO JettyUtils: Start Jetty 0.0.0.0:18080 for HistoryServerUI
25/07/02 22:49:43 INFO Utils: Successfully started service 'HistoryServerUI' on port 18080.
25/07/02 22:49:43 INFO HistoryServer: Bound HistoryServer to 0.0.0.0, and started at http://003658ffe276:18080
```