### PR TITLE
add support for local spark logs

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,7 +1,7 @@
 # https://taskfile.dev
 
 version: '3'
-
+silent: true
 vars:
   HELM_VERSION: v3.18.3
   KIND_VERSION: v0.29.0
@@ -85,6 +85,7 @@ tasks:
   create-cluster:
     desc: Create a Kind cluster for spark-history-server
     deps: [ensure-kind]
+    silent: false
     vars:
       CLUSTER_NAME: spark-history-server
     cmds:
@@ -109,6 +110,9 @@ tasks:
             protocol: TCP
         EOF
       - echo "Kind cluster '{{.CLUSTER_NAME}}' created with kubeconfig at {{.KUBECONFIG_PATH}}"
+      - echo "📋 To connect to your cluster:"
+      - echo "   export KUBECONFIG={{.KUBECONFIG_PATH}}"
+      - echo "   kubectl get pods -n {{.NAMESPACE}}"
     status:
       - "{{.BIN_DIR}}/kind get clusters | grep -q '^{{.CLUSTER_NAME}}$'"
       
@@ -131,21 +135,29 @@ tasks:
     vars:
       RELEASE_NAME: spark-history-server
       NAMESPACE: default
-      VALUES_FILE: '{{.VALUES_FILE | default ""}}'
+      VALUES_FILE: '{{.VALUES_FILE | default "tests/local-helm-values.yaml"}}'
     cmds:
-      - |
-        VALUES_ARGS=""
-        if [ -n "{{.VALUES_FILE}}" ]; then
-          VALUES_ARGS="-f {{.VALUES_FILE}}"
-        fi
       - |
         KUBECONFIG={{.KUBECONFIG_PATH}} {{.BIN_DIR}}/helm upgrade --install {{.RELEASE_NAME}} \
           --namespace {{.NAMESPACE}} \
           --create-namespace \
-          $VALUES_ARGS \
+          -f {{.VALUES_FILE}} \
           ./stable/spark-history-server
       - echo "🚀 Spark History Server chart installed as '{{.RELEASE_NAME}}' in namespace '{{.NAMESPACE}}'"
       - echo "✅ Installation complete!"
       - echo "📋 To connect to your cluster:"
       - echo "   export KUBECONFIG={{.KUBECONFIG_PATH}}"
       - echo "   kubectl get pods -n {{.NAMESPACE}}"
+  
+  uninstall-chart:
+    desc: Uninstall Spark History Server Helm chart from local Kind cluster
+    deps: [ensure-helm]
+    silent: true
+    vars:
+      RELEASE_NAME: spark-history-server
+      NAMESPACE: default
+    cmds:
+      - |
+        KUBECONFIG={{.KUBECONFIG_PATH}} {{.BIN_DIR}}/helm uninstall {{.RELEASE_NAME}} \
+          --namespace {{.NAMESPACE}}
+      - echo "🗑️ Spark History Server chart '{{.RELEASE_NAME}}' uninstalled from namespace '{{.NAMESPACE}}'"

--- a/stable/spark-history-server/templates/configmap.yaml
+++ b/stable/spark-history-server/templates/configmap.yaml
@@ -21,6 +21,10 @@ data:
     spark.hadoop.fs.azure.account.oauth2.client.secret.{{ .storageAccount }}.dfs.core.windows.net={{ .clientSecret }}
     spark.hadoop.fs.azure.account.oauth2.client.endpoint.{{ .storageAccount }}.dfs.core.windows.net=https://login.microsoftonline.com/{{ .tenantId }}/oauth2/token
     {{- end }}
+    {{- else if eq .Values.logStore.type "local" }}
+    {{- with .Values.logStore.local }}
+    spark.history.fs.logDirectory=file://{{ .directory }}
+    {{- end }}
     {{- end }}
     spark.history.fs.update.interval={{ .Values.historyServer.fs.update.interval }}
     spark.history.fs.cleaner.enabled={{ .Values.historyServer.fs.cleaner.enabled }}

--- a/stable/spark-history-server/tests/spark_config_test.yaml
+++ b/stable/spark-history-server/tests/spark_config_test.yaml
@@ -119,3 +119,47 @@ tests:
       - matchRegex:
           path: data['spark-defaults.conf']
           pattern: "spark\\.ui\\.proxyBase=/history"
+  - it: should provide the correct local configuration
+    set:
+      image:
+        tag: not-used
+      logStore:
+        type: local
+        local:
+          directory: "/spark-logs"
+    asserts:
+      - equal:
+          path: data
+          value:
+            log4j2.properties: |-
+              rootLogger.level = info
+              rootLogger.appenderRef.stdout.ref = console
+              appender.console.type = Console
+              appender.console.name = console
+              appender.console.target = SYSTEM_ERR
+              appender.console.layout.type = PatternLayout
+              appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n%ex
+
+              logger.spark.name = org.apache.spark
+              logger.spark.level = INFO
+              logger.hadoop.name = org.apache.hadoop
+              logger.hadoop.level = INFO
+              logger.s3a.name = org.apache.hadoop.fs.s3a
+              logger.s3a.level = DEBUG
+              logger.history.name = org.apache.spark.deploy.history.FsHistoryProvider
+              logger.history.level = DEBUG
+            spark-defaults.conf: |-
+              spark.history.fs.logDirectory=file:///spark-logs
+              spark.history.fs.update.interval=10s
+              spark.history.fs.cleaner.enabled=false
+              spark.history.fs.cleaner.interval=1d
+              spark.history.fs.cleaner.maxAge=7d
+              spark.history.fs.cleaner.maxNum=2147483647
+              spark.history.fs.endEventReparseChunkSize=1m
+              spark.history.fs.inProgressOptimization.enabled=true
+              spark.history.fs.driverlog.cleaner.enabled=false
+              spark.history.fs.driverlog.cleaner.interval=1d
+              spark.history.fs.driverlog.cleaner.maxAge=7d
+              spark.history.fs.eventLog.rolling.maxFilesToRetain=2147483647
+              spark.history.ui.maxApplications=2147483647
+              spark.history.ui.port=18080

--- a/stable/spark-history-server/values.schema.json
+++ b/stable/spark-history-server/values.schema.json
@@ -93,8 +93,8 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["s3", "abfs"],
-          "errorMessage": "logStore.type must be either 's3' or 'abfs'."
+          "enum": ["s3", "abfs", "local"],
+          "errorMessage": "logStore.type must be either 's3', 'abfs', or 'local'."
         },
         "s3": {
           "type": "object",
@@ -113,6 +113,12 @@
             "clientSecret": { "type": "string" },
             "tenantId": { "type": "string" },
             "eventLogsPath": { "type": "string" }
+          }
+        },
+        "local": {
+          "type": "object",
+          "properties": {
+            "directory": { "type": "string" }
           }
         }
       },
@@ -213,6 +219,32 @@
                     "clientSecret": "logStore.abfs.clientSecret is required when logStore.type is 'abfs'.",
                     "tenantId": "logStore.abfs.tenantId is required when logStore.type is 'abfs'.",
                     "eventLogsPath": "logStore.abfs.eventLogsPath is required when logStore.type is 'abfs'."
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "const": "local" } }
+          },
+          "then": {
+            "required": ["local"],
+            "properties": {
+              "local": {
+                "type": "object",
+                "properties": {
+                  "directory": {
+                    "type": "string",
+                    "not": { "pattern": "^<.*>$" },
+                    "errorMessage": "logStore.local.directory must be set to a real value, not a placeholder."
+                  }
+                },
+                "required": ["directory"],
+                "errorMessage": {
+                  "required": {
+                    "directory": "logStore.local.directory is required when logStore.type is 'local'."
                   }
                 }
               }

--- a/stable/spark-history-server/values.yaml
+++ b/stable/spark-history-server/values.yaml
@@ -37,9 +37,9 @@ serviceAccount:
   annotations: { }
 
 logStore:
-  # Enter the type of log store to use. Supported values are "s3" and "abfs".
+  # Enter the type of log store to use. Supported values are "s3", "abfs", and "local".
   # Remember
-  type: "s3"  # or "abfs" depending on which cloud provider you're targeting
+  type: "s3"  # or "abfs" or "local" depending on which storage you're targeting
 
   s3:
     # Ensure IRSA roles has permissions to read the files for the given S3 bucket
@@ -54,6 +54,9 @@ logStore:
     clientSecret: <CLIENT SECRET>
     tenantId: <TENANT ID>
     eventLogsPath: <PREFIX FOR SPARK EVENT LOGS>
+    
+  local:
+    directory: "/home"
 
 # Extra configuration for spark-defaults.conf
 #sparkConf: |-

--- a/tests/local-helm-values.yaml
+++ b/tests/local-helm-values.yaml
@@ -1,0 +1,2 @@
+logStore:
+  type: "local"


### PR DESCRIPTION
This adds support for `local` type, in addition to `s3` and `abfs`. This allows us to test charts locally much easily.