### PR TITLE
add support for nodePort

### DIFF
--- a/stable/spark-history-server/templates/service.yaml
+++ b/stable/spark-history-server/templates/service.yaml
@@ -11,5 +11,11 @@ spec:
       targetPort: {{ .Values.service.internalPort }}
       protocol: TCP
       name: {{ .Chart.Name }}
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "spark-history-server.selectorLabels" . | nindent 4 }}
+    {{- with .Values.podLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}

--- a/stable/spark-history-server/tests/service_test.yaml
+++ b/stable/spark-history-server/tests/service_test.yaml
@@ -1,0 +1,77 @@
+suite: test service configuration
+templates:
+  - service.yaml
+tests:
+  - it: should configure a ClusterIP service correctly
+    set:
+      service:
+        type: ClusterIP
+        externalPort: 80
+        internalPort: 18080
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 18080
+      - isNull:
+          path: spec.ports[0].nodePort
+
+  - it: should configure a NodePort service correctly with specific nodePort
+    set:
+      service:
+        type: NodePort
+        externalPort: 80
+        internalPort: 18080
+        nodePort: 30080
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 18080
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30080
+
+  - it: should configure a NodePort service without specifying nodePort
+    set:
+      service:
+        type: NodePort
+        externalPort: 80
+        internalPort: 18080
+        nodePort: null
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 18080
+      - isNull:
+          path: spec.ports[0].nodePort
+
+  - it: should have correct selector labels with custom labels
+    set:
+      podLabels:
+        custom-label: test-value
+        environment: testing
+    asserts:
+      - equal:
+          path: spec.selector
+          value:
+            app.kubernetes.io/name: spark-history-server
+            app.kubernetes.io/instance: RELEASE-NAME
+            custom-label: test-value
+            environment: testing

--- a/stable/spark-history-server/values.schema.json
+++ b/stable/spark-history-server/values.schema.json
@@ -340,6 +340,34 @@
         }
       }
     },
+    "service": {
+      "type": "object",
+      "properties": {
+        "externalPort": { "type": "integer" },
+        "internalPort": { "type": "integer" },
+        "type": { "type": "string" },
+        "nodePort": {
+          "type": ["integer", "null"],
+          "minimum": 30000,
+          "maximum": 32767,
+          "errorMessage": "service.nodePort must be between 30000 and 32767 when service.type is NodePort"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "type": { "const": "NodePort" } }
+          },
+          "then": {
+            "properties": {
+              "nodePort": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      ]
+    },
     "ingress": {
       "type": "object",
       "properties": {

--- a/stable/spark-history-server/values.yaml
+++ b/stable/spark-history-server/values.yaml
@@ -162,6 +162,7 @@ service:
   externalPort: 80
   internalPort: 18080
   type: ClusterIP
+  nodePort: null
 
 ingress:
   enabled: false


### PR DESCRIPTION
This adds support for nodePort in the service object. It's useful for local testing.