### PR TITLE
add support for custom volumes

### DIFF
--- a/stable/spark-history-server/templates/deployment.yaml
+++ b/stable/spark-history-server/templates/deployment.yaml
@@ -47,6 +47,9 @@ spec:
             name: {{ template "spark-history-server.fullname" . }}
         - name: spark-logs
           emptyDir: { }
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -76,6 +79,9 @@ spec:
               subPath: log4j2.properties
             - name: spark-logs
               mountPath: /opt/spark/logs
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.internalPort }}

--- a/stable/spark-history-server/templates/statefulset.yaml
+++ b/stable/spark-history-server/templates/statefulset.yaml
@@ -46,6 +46,9 @@ spec:
           emptyDir: { }
         - name: tmp-dir
           emptyDir: { }
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -81,6 +84,9 @@ spec:
               mountPath: {{ .Values.persistence.mountPath }}
             - name: tmp-dir
               mountPath: /tmp
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.internalPort }}

--- a/stable/spark-history-server/tests/pod_test.yaml
+++ b/stable/spark-history-server/tests/pod_test.yaml
@@ -1,0 +1,157 @@
+suite: test pod configuration
+templates:
+  - deployment.yaml
+  - statefulset.yaml
+tests:
+  - it: should add custom volumes to deployment when specified
+    template: deployment.yaml
+    set:
+      historyServer.store.hybridStore.enabled: false
+      volumes:
+        - name: test-volume
+          emptyDir: {}
+        - name: config-volume-custom
+          configMap:
+            name: test-config
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-spark-history-server
+      - equal:
+          path: spec.template.spec.volumes[2].name
+          value: test-volume
+      - equal:
+          path: spec.template.spec.volumes[2].emptyDir
+          value: {}
+      - equal:
+          path: spec.template.spec.volumes[3].name
+          value: config-volume-custom
+      - equal:
+          path: spec.template.spec.volumes[3].configMap.name
+          value: test-config
+
+  - it: should add custom volumes to statefulset when specified
+    template: statefulset.yaml
+    set:
+      historyServer.store.hybridStore.enabled: true
+      volumes:
+        - name: test-volume
+          emptyDir: {}
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-spark-history-server
+      - equal:
+          path: spec.template.spec.volumes[3].name
+          value: test-volume
+      - equal:
+          path: spec.template.spec.volumes[3].emptyDir
+          value: {}
+
+  - it: should add custom volumeMounts to statefulset when specified
+    template: statefulset.yaml
+    set:
+      historyServer.store.hybridStore.enabled: true
+      volumeMounts:
+        - name: test-volume
+          mountPath: /test
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-spark-history-server
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[5].name
+          value: test-volume
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[5].mountPath
+          value: /test
+
+  - it: should add custom volumeMounts to deployment when specified
+    template: deployment.yaml
+    set:
+      historyServer.store.hybridStore.enabled: false
+      volumeMounts:
+        - name: test-volume
+          mountPath: /test
+          readOnly: true
+        - name: config-volume-custom
+          mountPath: /config
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-spark-history-server
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[3].name
+          value: test-volume
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[3].mountPath
+          value: /test
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[3].readOnly
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[4].name
+          value: config-volume-custom
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[4].mountPath
+          value: /config
+
+  - it: should add both volumes and volumeMounts to deployment when specified
+    template: deployment.yaml
+    set:
+      historyServer.store.hybridStore.enabled: false
+      volumes:
+        - name: shared-data
+          emptyDir: {}
+      volumeMounts:
+        - name: shared-data
+          mountPath: /shared-data
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-spark-history-server
+      - equal:
+          path: spec.template.spec.volumes[2].name
+          value: shared-data
+      - equal:
+          path: spec.template.spec.volumes[2].emptyDir
+          value: {}
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[3].name
+          value: shared-data
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[3].mountPath
+          value: /shared-data
+
+  - it: should add both volumes and volumeMounts to statefulset when specified
+    template: statefulset.yaml
+    set:
+      historyServer.store.hybridStore.enabled: true
+      volumes:
+        - name: shared-data
+          emptyDir: {}
+      volumeMounts:
+        - name: shared-data
+          mountPath: /shared-data
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-spark-history-server
+      - equal:
+          path: spec.template.spec.volumes[3].name
+          value: shared-data
+      - equal:
+          path: spec.template.spec.volumes[3].emptyDir
+          value: {}
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[5].name
+          value: shared-data
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[5].mountPath
+          value: /shared-data

--- a/stable/spark-history-server/values.schema.json
+++ b/stable/spark-history-server/values.schema.json
@@ -399,6 +399,20 @@
           }
         }
       ]
+    },
+    "volumes": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Additional volumes to add to the pod"
+    },
+    "volumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Additional volumeMounts to add to the container"
     }
   }
 }

--- a/stable/spark-history-server/values.yaml
+++ b/stable/spark-history-server/values.yaml
@@ -208,3 +208,21 @@ nodeSelector: { }
 tolerations: [ ]
 
 affinity: { }
+
+# Additional volumes to add to the pod
+volumes: []
+  # Example:
+  # - name: extra-volume
+  #   persistentVolumeClaim:
+  #     claimName: my-pvc
+  # - name: config-volume
+  #   configMap:
+  #     name: my-configmap
+
+# Additional volumeMounts to add to the container
+volumeMounts: []
+# Example:
+# - name: extra-volume
+#   mountPath: /mnt/extra
+# - name: config-volume
+#   mountPath: /etc/config


### PR DESCRIPTION
This adds support for custom volumes to be mounted. Useful when you have existing event logs stored in places other than cloud storage.

fixes: #39 